### PR TITLE
removing expo dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-asset-utils",
+  "name": "expo-asset-utils-example",
   "version": "0.0.0",
   "description": "expo-asset-utils simple example",
   "author": "support@expo.io",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,18 @@
     "email": "bacon@expo.io",
     "name": "Evan Bacon"
   },
-  "keywords": ["expo", "asset", "utils", "react-native", "react"],
+  "keywords": [
+    "expo",
+    "asset",
+    "utils",
+    "react-native",
+    "react"
+  ],
   "license": "MIT",
   "readmeFilename": "README.md",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "peerDependencies": {
     "react-native": "*",
@@ -46,7 +54,9 @@
     "example": "examples",
     "lib": "src"
   },
-  "pre-push": ["lint"],
+  "pre-push": [
+    "lint"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
@@ -56,5 +66,9 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "sync-example": "npm run build && rsync -rv dist example/node_modules/expo-asset-utils"
+  },
+  "dependencies": {
+    "expo-asset": "^1.0.0",
+    "expo-file-system": "^1.0.0"
   }
 }

--- a/src/cacheAssetsAsync.js
+++ b/src/cacheAssetsAsync.js
@@ -1,6 +1,6 @@
 // @flow
 import { Image } from 'react-native';
-import { Asset, Font } from 'expo';
+import { Asset } from 'expo-asset';
 
 export type CacheOptions = {
   images: Array,
@@ -30,5 +30,10 @@ function cacheImages(images: Array): Promise {
 }
 
 function cacheFonts(fonts: Array): Array<Promise> {
-  return fonts.map(font => Font.loadAsync(font));
+  try {
+    const { Font } = require('expo');
+    return fonts.map(font => Font.loadAsync(font));
+  } catch (error) {
+    throw new Error('Expo have to be installed if you want to use Font');
+  }
 }

--- a/src/copyAssetToSameDirectoryWithNewNameAsync.js
+++ b/src/copyAssetToSameDirectoryWithNewNameAsync.js
@@ -1,5 +1,5 @@
 // @flow
-import Expo from 'expo';
+import { FileSystem } from 'expo-file-system';
 import uriAsync from './uriAsync';
 import replaceNameInUri from './replaceNameInUri';
 
@@ -9,7 +9,7 @@ async function copyAssetToSameDirectoryWithNewNameAsync(
 ): Promise<string> {
   const url = await uriAsync(fileReference);
   const nextUrl = replaceNameInUri(url, name);
-  await Expo.FileSystem.copyAsync({ from: url, to: nextUrl });
+  await FileSystem.copyAsync({ from: url, to: nextUrl });
   return nextUrl;
 }
 

--- a/src/fileInfoAsync.js
+++ b/src/fileInfoAsync.js
@@ -1,5 +1,5 @@
 // @flow
-import Expo from 'expo';
+import { FileSystem } from 'expo-file-system';
 
 import filenameFromUri from './filenameFromUri';
 
@@ -12,7 +12,7 @@ function isLocalUri(uri: string): boolean {
 }
 
 async function getHashAsync(uri: string): Promise<string> {
-  const { md5 } = await Expo.FileSystem.getInfoAsync(uri, { md5: true });
+  const { md5 } = await FileSystem.getInfoAsync(uri, { md5: true });
   return md5;
 }
 
@@ -36,11 +36,11 @@ async function fileInfoAsync(url: ?string, name: string): Promise<ImageData> {
     return null;
   }
   name = name || filenameFromUri(url);
-  const localUri = Expo.FileSystem.cacheDirectory + name;
+  const localUri = FileSystem.cacheDirectory + name;
 
   if (isAssetLibraryUri(url)) {
     /// ios asset: we need to copy this over and then get the hash
-    await Expo.FileSystem.copyAsync({
+    await FileSystem.copyAsync({
       from: url,
       to: localUri,
     });
@@ -64,7 +64,7 @@ async function fileInfoAsync(url: ?string, name: string): Promise<ImageData> {
     return file;
   } else {
     /// remote image: download first
-    const { uri, md5: hash } = await Expo.FileSystem.downloadAsync(url, localUri, {
+    const { uri, md5: hash } = await FileSystem.downloadAsync(url, localUri, {
       md5: true,
     });
     return { uri, name, hash };

--- a/src/fromUriAsync.js
+++ b/src/fromUriAsync.js
@@ -1,5 +1,5 @@
 // @flow
-import Expo from 'expo';
+import { Asset } from 'expo-asset';
 import imageSizeAsync from './imageSizeAsync';
 import fileInfoAsync from './fileInfoAsync';
 
@@ -16,7 +16,7 @@ function getExtension(url: string): string {
     .toLowerCase();
 }
 
-async function fromUriAsync(remoteUri: string, fileName: ?string): Promise<Expo.Asset> {
+async function fromUriAsync(remoteUri: string, fileName: ?string): Promise<Asset> {
   const { uri, name, hash } = await fileInfoAsync(remoteUri, fileName);
 
   if (uri) {
@@ -29,7 +29,7 @@ async function fromUriAsync(remoteUri: string, fileName: ?string): Promise<Expo.
       height = size.height;
     }
 
-    return new Expo.Asset({ name, type, hash, uri, width, height });
+    return new Asset({ name, type, hash, uri, width, height });
   }
 }
 

--- a/src/resolveAsync.js
+++ b/src/resolveAsync.js
@@ -1,5 +1,5 @@
 // @flow
-import Expo, { Asset } from 'expo';
+import { Asset } from 'expo-asset';
 import isReactImageFormat from './isReactImageFormat';
 import fromUriAsync from './fromUriAsync';
 
@@ -15,10 +15,7 @@ export type Options = {
   fileName: string,
 };
 
-const resolveAsync = async (
-  fileReference: WildCard,
-  options: Options = {}
-): Promise<?Expo.Asset> => {
+const resolveAsync = async (fileReference: WildCard, options: Options = {}): Promise<?Asset> => {
   if (fileReference instanceof Asset) {
     /// Asset
     if (!fileReference.localUri) {


### PR DESCRIPTION
#Why 

expo-asset-utils doesn't need expo as dependency. It needs only expo-asset, expo-file-system and Expo.Font (it's not a module yet).

#How 

I added expo modules into dependency list and changed imports

#Test 

I tested this with example app.

#Issues

expo-asset is not able to download non-static 'assets', because of that some tests in example app are not passing