### PR TITLE
Add support for SDK32

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sync-example": "npm run build && rsync -rv dist example/node_modules/expo-asset-utils"
   },
   "dependencies": {
-    "expo-asset": "^1.0.0",
-    "expo-file-system": "^1.0.0"
+    "expo-asset": "~2.0.0",
+    "expo-file-system": "~2.0.0"
   }
 }


### PR DESCRIPTION
Using `expo-asset-utils` with SDK32 throws an error.

```
undefined is not an object (evaluating 'Constants.manifest')
```