### PR TITLE
Added asset:/ scheme to support android bundled assets on react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "lib": "src"
   },
   "peerDependencies": {
+    "@unimodules/core": "*",
     "expo-asset": "~4.0.0",
     "expo-file-system": "~4.0.0",
-    "expo-font": "~4.0.0",
-    "@unimodules/core": "*"
+    "expo-font": "~4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -72,6 +72,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.1.0",
+    "flow-bin": "^0.138.0",
     "husky": "^0.14.3",
     "jest": "^22.1.3",
     "jest-expo": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-asset-utils",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Utilities for converting files into Expo Assets",
   "author": "Evan Bacon <bacon@expo.io> (https://expo.io/)",
   "files": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@unimodules/core": "*",
     "expo-asset": "~4.0.0",
     "expo-file-system": "~9.2.0",
-    "expo-font": "~4.0.0"
+    "expo-font": "~8.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-asset-utils",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Utilities for converting files into Expo Assets",
   "author": "Evan Bacon <bacon@expo.io> (https://expo.io/)",
   "files": [
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "@unimodules/core": "*",
     "expo-asset": "~4.0.0",
-    "expo-file-system": "~4.0.0",
+    "expo-file-system": "~9.2.0",
     "expo-font": "~4.0.0"
   },
   "devDependencies": {

--- a/src/fileInfoAsync.js
+++ b/src/fileInfoAsync.js
@@ -4,7 +4,9 @@ import { Platform } from '@unimodules/core';
 import filenameFromUri from './filenameFromUri';
 
 function isAssetLibraryUri(uri: string): boolean {
-  return uri.toLowerCase().startsWith('assets-library://');
+  return (
+    uri.toLowerCase().startsWith('assets-library://') || uri.toLowerCase().startsWith('asset:/')
+  );
 }
 
 function isLocalUri(uri: string): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3366,6 +3366,11 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flow-bin@^0.138.0:
+  version "0.138.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.138.0.tgz#a0c81a3dd1ed34771b33b7e91078ed260301aa17"
+  integrity sha512-y3twwNeN0FWEK0vvJo/5SiC/OQVlhubGRyOPIS6p49b2yiiWE/cBFG/aC9kFXFfh7Orewe5O5B2X0+IiEOCYIw==
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Tested on android, I was able to read an image from asset:/ folder (bundled from android/app/src/main/assets folder)